### PR TITLE
[MCC-195656] Implement validation rules for TSDV

### DIFF
--- a/Medidata.Cloud.ExcelLoader.Tests/CellTypeConverters/DecimalConverterTests.cs
+++ b/Medidata.Cloud.ExcelLoader.Tests/CellTypeConverters/DecimalConverterTests.cs
@@ -79,7 +79,7 @@ namespace Medidata.Cloud.ExcelLoader.Tests.CellTypeConverters
             Assert.IsTrue(success1);
             Assert.IsTrue(success2);
             Assert.AreEqual("0.123", value0);
-            Assert.AreEqual("10000000000", value1);
+            Assert.AreEqual("1000000000", value1);
             Assert.AreEqual("-12.84848715", value2);
 
         }

--- a/Medidata.Cloud.ExcelLoader.Tests/DefaultSequentialRuleValidatorTests.cs
+++ b/Medidata.Cloud.ExcelLoader.Tests/DefaultSequentialRuleValidatorTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Medidata.Cloud.ExcelLoader.Validations;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Ploeh.AutoFixture;
@@ -22,7 +23,7 @@ namespace Medidata.Cloud.ExcelLoader.Tests
         public void AllRulesAreChecked()
         {
             // Arrange
-            var blockPlan = _fixture.Create<IExcelParser>();
+            var blockPlan = _fixture.Create<IExcelLoader>();
             var messages = _fixture.CreateMany<IValidationError>().ToArray();
             var validationRules = new[]
                                   {
@@ -46,7 +47,7 @@ namespace Medidata.Cloud.ExcelLoader.Tests
         public void StopRuleIfShouldContinueIsFalse()
         {
             // Arrange
-            var blockPlan = _fixture.Create<IExcelParser>();
+            var blockPlan = _fixture.Create<IExcelLoader>();
             var messages = _fixture.CreateMany<IValidationMessage>().ToArray();
             var validationRules = new[]
                                   {
@@ -70,7 +71,7 @@ namespace Medidata.Cloud.ExcelLoader.Tests
         {
             var ruleResult = _fixture.Create<IValidationRuleResult>();
             ruleResult.Stub(x => x.ShouldContinue).Return(canContinue);
-            ruleResult.Stub(x => x.Message).Return(message);
+            ruleResult.Stub(x => x.Messages).Return(new List<IValidationMessage>{ message });
 
             var rule = _fixture.Create<IValidationRule>();
             rule.Stub(x => x.Check(null)).IgnoreArguments().Return(ruleResult);

--- a/Medidata.Cloud.ExcelLoader/ColumnDefinition.cs
+++ b/Medidata.Cloud.ExcelLoader/ColumnDefinition.cs
@@ -4,5 +4,6 @@ namespace Medidata.Cloud.ExcelLoader
     {
         public string PropertyName { get; set; }
         public string Header { get; set; }
+        public bool ExtraProperty { get; set; }
     }
 }

--- a/Medidata.Cloud.ExcelLoader/Helpers/SheetDefinitionExtensions.cs
+++ b/Medidata.Cloud.ExcelLoader/Helpers/SheetDefinitionExtensions.cs
@@ -9,7 +9,7 @@
 
         public static ISheetDefinition AddColumn(this ISheetDefinition target, string propertyName, string header)
         {
-            return target.AddColumn(new ColumnDefinition {PropertyName = propertyName, Header = header});
+            return target.AddColumn(new ColumnDefinition {PropertyName = propertyName, Header = header, ExtraProperty = true});
         }
     }
 }

--- a/Medidata.Cloud.ExcelLoader/IColumnDefinition.cs
+++ b/Medidata.Cloud.ExcelLoader/IColumnDefinition.cs
@@ -4,5 +4,6 @@ namespace Medidata.Cloud.ExcelLoader
     {
         string PropertyName { get; set; }
         string Header { get; set; }
+        bool ExtraProperty { get; set; }
     }
 }

--- a/Medidata.Cloud.ExcelLoader/ISheetDefinition.cs
+++ b/Medidata.Cloud.ExcelLoader/ISheetDefinition.cs
@@ -7,6 +7,7 @@ namespace Medidata.Cloud.ExcelLoader
         string Name { get; }
         bool AcceptExtraProperties { get; }
         IEnumerable<IColumnDefinition> ColumnDefinitions { get; }
+        IEnumerable<IColumnDefinition> ExtraColumnDefinitions { get; }
         ISheetDefinition AddColumn(IColumnDefinition columnDefinition);
     }
 }

--- a/Medidata.Cloud.ExcelLoader/Medidata.Cloud.ExcelLoader.csproj
+++ b/Medidata.Cloud.ExcelLoader/Medidata.Cloud.ExcelLoader.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Validations\IValidator.cs" />
     <Compile Include="Validations\Rules\ValidationRuleBase.cs" />
     <Compile Include="Validations\Rules\ValidationRuleResult.cs" />
+    <Compile Include="Validations\SheetValidator.cs" />
     <Compile Include="Validations\ValidationError.cs" />
     <Compile Include="Validations\ValidationResult.cs" />
     <Compile Include="Validations\ValidationWarning.cs" />

--- a/Medidata.Cloud.ExcelLoader/Properties/AssemblyInfo.cs
+++ b/Medidata.Cloud.ExcelLoader/Properties/AssemblyInfo.cs
@@ -37,5 +37,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("0.1.5.0")]
-[assembly: AssemblyFileVersion("0.1.5.0")]
+[assembly: AssemblyVersion("0.1.6.0")]
+[assembly: AssemblyFileVersion("0.1.6.0")]

--- a/Medidata.Cloud.ExcelLoader/SheetDecorators/AutoFitColumnSheetDecorator.cs
+++ b/Medidata.Cloud.ExcelLoader/SheetDecorators/AutoFitColumnSheetDecorator.cs
@@ -67,7 +67,7 @@ namespace Medidata.Cloud.ExcelLoader.SheetDecorators
             var stringFont = new System.Drawing.Font(font, fontSize);
             var textSize = TextRenderer.MeasureText(text, stringFont);
             var width = (textSize.Width / (double) 7 * 256 - 18) / 256;
-            width = (double) decimal.Round((decimal) width + 0.2M, 2);
+            width = (double) decimal.Round((decimal) width + 0.2M + 2.29M, 2);
             return width;
         }
 

--- a/Medidata.Cloud.ExcelLoader/SheetDefinition.cs
+++ b/Medidata.Cloud.ExcelLoader/SheetDefinition.cs
@@ -14,6 +14,10 @@ namespace Medidata.Cloud.ExcelLoader
         public bool AcceptExtraProperties { get; set; }
         public IEnumerable<IColumnDefinition> ColumnDefinitions { get; set; }
 
+        public IEnumerable<IColumnDefinition> ExtraColumnDefinitions {
+            get { return ColumnDefinitions.Where(x => x.ExtraProperty); }
+        }
+
         public ISheetDefinition AddColumn(IColumnDefinition columnDefinition)
         {
             if (columnDefinition == null) throw new ArgumentNullException("columnDefinition");
@@ -37,7 +41,8 @@ namespace Medidata.Cloud.ExcelLoader
                                  select new ColumnDefinition
                                         {
                                             PropertyName = prop.Name,
-                                            Header = headerAtt != null ? headerAtt.Header : prop.Name
+                                            Header = headerAtt != null ? headerAtt.Header : prop.Name,
+                                            ExtraProperty = false
                                         };
 
             var sheetDefinition = new SheetDefinition

--- a/Medidata.Cloud.ExcelLoader/Validations/DefaultSequentialRuleValidator.cs
+++ b/Medidata.Cloud.ExcelLoader/Validations/DefaultSequentialRuleValidator.cs
@@ -14,17 +14,17 @@ namespace Medidata.Cloud.ExcelLoader.Validations
             _rules = rules ?? Enumerable.Empty<IValidationRule>();
         }
 
-        public IValidationResult Validate(IExcelParser excelParser)
+        public IValidationResult Validate(IExcelLoader excelLoader)
         {
-            if (excelParser == null) throw new ArgumentNullException("excelParser");
+            if (excelLoader == null) throw new ArgumentNullException("excelParser");
 
-            var result = new ValidationResult {ValidationTarget = excelParser};
+            var result = new ValidationResult {ValidationTarget = excelLoader};
 
             try
             {
-                foreach (var ruleResult in _rules.Select(r => r.Check(excelParser)))
+                foreach (var ruleResult in _rules.Select(r => r.Check(excelLoader)))
                 {
-                    result.Messages.Add(ruleResult.Message);
+                    result.Messages.AddRange(ruleResult.Messages);
                     if (!ruleResult.ShouldContinue)
                     {
                         break;

--- a/Medidata.Cloud.ExcelLoader/Validations/IValidationResult.cs
+++ b/Medidata.Cloud.ExcelLoader/Validations/IValidationResult.cs
@@ -4,7 +4,7 @@ namespace Medidata.Cloud.ExcelLoader.Validations
 {
     public interface IValidationResult
     {
-        IExcelParser ValidationTarget { get; }
+        IExcelLoader ValidationTarget { get; }
         IList<IValidationMessage> Messages { get; }
     }
 }

--- a/Medidata.Cloud.ExcelLoader/Validations/IValidationRule.cs
+++ b/Medidata.Cloud.ExcelLoader/Validations/IValidationRule.cs
@@ -2,6 +2,6 @@ namespace Medidata.Cloud.ExcelLoader.Validations
 {
     public interface IValidationRule
     {
-        IValidationRuleResult Check(IExcelParser excelParser);
+        IValidationRuleResult Check(IExcelLoader excelLoader);
     }
 }

--- a/Medidata.Cloud.ExcelLoader/Validations/IValidationRuleResult.cs
+++ b/Medidata.Cloud.ExcelLoader/Validations/IValidationRuleResult.cs
@@ -1,8 +1,10 @@
+using System.Collections.Generic;
+
 namespace Medidata.Cloud.ExcelLoader.Validations
 {
     public interface IValidationRuleResult
     {
-        IValidationMessage Message { get; }
+        IList<IValidationMessage> Messages { get; }
         bool ShouldContinue { get; }
     }
 }

--- a/Medidata.Cloud.ExcelLoader/Validations/IValidator.cs
+++ b/Medidata.Cloud.ExcelLoader/Validations/IValidator.cs
@@ -2,6 +2,6 @@ namespace Medidata.Cloud.ExcelLoader.Validations
 {
     public interface IValidator
     {
-        IValidationResult Validate(IExcelParser excelParser);
+        IValidationResult Validate(IExcelLoader excelLoader);
     }
 }

--- a/Medidata.Cloud.ExcelLoader/Validations/Rules/ValidationRuleBase.cs
+++ b/Medidata.Cloud.ExcelLoader/Validations/Rules/ValidationRuleBase.cs
@@ -1,18 +1,19 @@
 using System;
+using System.Collections.Generic;
 
 namespace Medidata.Cloud.ExcelLoader.Validations.Rules
 {
     public abstract class ValidationRuleBase : IValidationRule
     {
-        public virtual IValidationRuleResult Check(IExcelParser excelParser)
+        public virtual IValidationRuleResult Check(IExcelLoader excelLoader)
         {
-            var shouldContinue = true;
+            var shouldContinue = false;
             Action next = () => { shouldContinue = true; };
-            IValidationMessage message;
-            Validate(excelParser, out message, next);
-            return new ValidationRuleResult {Message = message, ShouldContinue = shouldContinue};
+            IList<IValidationMessage> messages;
+            Validate(excelLoader, out messages, next);
+            return new ValidationRuleResult {Messages = messages, ShouldContinue = shouldContinue};
         }
 
-        protected abstract void Validate(IExcelParser blockPlan, out IValidationMessage message, Action next);
+        protected abstract void Validate(IExcelLoader excelLoader, out IList<IValidationMessage> message, Action next);
     }
 }

--- a/Medidata.Cloud.ExcelLoader/Validations/Rules/ValidationRuleResult.cs
+++ b/Medidata.Cloud.ExcelLoader/Validations/Rules/ValidationRuleResult.cs
@@ -1,8 +1,10 @@
+using System.Collections.Generic;
+
 namespace Medidata.Cloud.ExcelLoader.Validations.Rules
 {
     internal class ValidationRuleResult : IValidationRuleResult
     {
-        public IValidationMessage Message { get; set; }
+        public IList<IValidationMessage> Messages { get; set; }
         public bool ShouldContinue { get; set; }
     }
 }

--- a/Medidata.Cloud.ExcelLoader/Validations/SheetValidator.cs
+++ b/Medidata.Cloud.ExcelLoader/Validations/SheetValidator.cs
@@ -1,0 +1,10 @@
+﻿namespace Medidata.Cloud.ExcelLoader.Validations
+{
+    public class SheetValidator<T> : IValidator
+    {
+        public IValidationResult Validate(IExcelLoader excelLoader)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/Medidata.Cloud.ExcelLoader/Validations/ValidationResult.cs
+++ b/Medidata.Cloud.ExcelLoader/Validations/ValidationResult.cs
@@ -9,7 +9,7 @@ namespace Medidata.Cloud.ExcelLoader.Validations
             Messages = new List<IValidationMessage>();
         }
 
-        public IExcelParser ValidationTarget { get; set; }
+        public IExcelLoader ValidationTarget { get; set; }
         public IList<IValidationMessage> Messages { get; private set; }
     }
 }

--- a/Medidata.Rave.Tsdv.Loader.Tests/Medidata.Rave.Tsdv.Loader.Tests.csproj
+++ b/Medidata.Rave.Tsdv.Loader.Tests/Medidata.Rave.Tsdv.Loader.Tests.csproj
@@ -75,11 +75,16 @@
   </Choose>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Validations\Rules\ValidateBlockPlanSettingTiersTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Medidata.Cloud.ExcelLoader\Medidata.Cloud.ExcelLoader.csproj">
+      <Project>{9b06a417-162e-45d4-ad93-7e274857599c}</Project>
+      <Name>Medidata.Cloud.ExcelLoader</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Medidata.Rave.Tsdv.Loader\Medidata.Rave.Tsdv.Loader.csproj">
       <Project>{ABC3AD09-99B9-4CCF-B771-75B9597C05AE}</Project>
       <Name>Medidata.Rave.Tsdv.Loader</Name>

--- a/Medidata.Rave.Tsdv.Loader.Tests/Validations/Rules/ValidateBlockPlanSettingTiersTests.cs
+++ b/Medidata.Rave.Tsdv.Loader.Tests/Validations/Rules/ValidateBlockPlanSettingTiersTests.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Medidata.Cloud.ExcelLoader;
+using Medidata.Rave.Tsdv.Loader.Validations.Rules;
+using Medidata.Interfaces.Localization;
+using Medidata.Rave.Tsdv.Loader.SheetDefinitions.v1;
+using Medidata.Rave.Tsdv.Loader.Validations.Rules;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.AutoRhinoMock;
+using Rhino.Mocks;
+
+
+namespace Medidata.Rave.Tsdv.Loader.Tests.Validations.Rules
+{
+    [TestClass]
+    public class ValidateBlockPlanSettingTiersTests
+    {
+        private IFixture _fixture;
+        private ILocalization _localization;
+
+        [TestInitialize]
+        public void Init()
+        {
+            _fixture = new Fixture().Customize(new AutoRhinoMockCustomization());
+            _localization = _fixture.Create<ILocalization>();
+        }
+
+        [TestMethod]
+        public void AllTiersAreSame()
+        {
+            // Arrange
+            var tierNames = _fixture.CreateMany<string>().ToList();
+            var customTiers = tierNames.Select(x => new CustomTier {TierName = x}).ToList();
+            var extraColumns = tierNames.Select(x => new ColumnDefinition {ExtraProperty = true, PropertyName = x});
+
+            var excelLoader = SetupExcelLoader(customTiers, extraColumns);
+
+            // Act
+            var sut = new ValidateBlockPlanSettingTiers(_localization);
+            var result = sut.Check(excelLoader);
+
+            // Assert
+            Assert.IsFalse(result.Messages.Any());
+            Assert.IsTrue(result.ShouldContinue);
+        }
+
+        [TestMethod]
+        public void AllTiersAreDifferent()
+        {
+            // Arrange
+            var tierNames = _fixture.CreateMany<string>().ToList();
+            var customTiers = tierNames.Select(x => new CustomTier { TierName = x }).ToList();
+
+            var tierNames2 = _fixture.CreateMany<string>().ToList();
+            var extraColumns = tierNames2.Select(x => new ColumnDefinition { ExtraProperty = true, PropertyName = x });
+
+            var excelLoader = SetupExcelLoader(customTiers, extraColumns);
+
+            // Act
+            var sut = new ValidateBlockPlanSettingTiers(_localization);
+            var result = sut.Check(excelLoader);
+
+            // Assert
+            Assert.IsTrue(result.Messages.Any());
+            Assert.AreEqual(result.Messages.Count, tierNames2.Count);
+            Assert.IsFalse(result.ShouldContinue);
+        }
+
+        [TestMethod]
+        public void OneBlockTierIsDifferent()
+        {
+            // Arrange
+            var tierNames = _fixture.CreateMany<string>().ToList();
+            var customTiers = tierNames.Select(x => new CustomTier { TierName = x }).ToList();
+
+            tierNames[0] = _fixture.Create<string>();
+            var extraColumns = tierNames.Select(x => new ColumnDefinition { ExtraProperty = true, PropertyName = x });
+
+            var excelLoader = SetupExcelLoader(customTiers, extraColumns);
+
+            // Act
+            var sut = new ValidateBlockPlanSettingTiers(_localization);
+            var result = sut.Check(excelLoader);
+
+            // Assert
+            Assert.IsTrue(result.Messages.Any()); 
+            Assert.AreEqual(result.Messages.Count, 1);
+            Assert.IsFalse(result.ShouldContinue);
+        }
+
+        public IExcelLoader SetupExcelLoader(IList<CustomTier> customTiers, IEnumerable<IColumnDefinition> columns)
+        {
+            var sheetBlockPlanSetting = _fixture.Create<ISheetInfo<BlockPlanSetting>>();
+            sheetBlockPlanSetting.Stub(x => x.Definition.ExtraColumnDefinitions)
+                .Return(columns);
+
+            var sheetCustomTier = _fixture.Create<ISheetInfo<CustomTier>>();
+            sheetCustomTier.Stub(x => x.Data)
+                .Return(customTiers);
+            
+            var excelLoader = _fixture.Create<IExcelLoader>();
+            excelLoader.Stub(x => x.Sheet<BlockPlanSetting>())
+                .Return(sheetBlockPlanSetting);
+            excelLoader.Stub(x => x.Sheet<CustomTier>())
+                .Return(sheetCustomTier);
+
+            return excelLoader;
+        }
+
+    }
+}

--- a/Medidata.Rave.Tsdv.Loader/Medidata.Rave.Tsdv.Loader.csproj
+++ b/Medidata.Rave.Tsdv.Loader/Medidata.Rave.Tsdv.Loader.csproj
@@ -70,7 +70,7 @@
     <Compile Include="Validations\Rules\ValidateTierFields.cs" />
     <Compile Include="Validations\Rules\ValidateTierFolders.cs" />
     <Compile Include="Validations\Rules\ValidateTierForms.cs" />
-    <Compile Include="Validations\ValdiateBlockPlans.cs" />
+    <Compile Include="Validations\Rules\ValdiateBlockPlans.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Medidata.Rave.Tsdv.Loader.nuspec" />

--- a/Medidata.Rave.Tsdv.Loader/Medidata.Rave.Tsdv.Loader.csproj
+++ b/Medidata.Rave.Tsdv.Loader/Medidata.Rave.Tsdv.Loader.csproj
@@ -64,6 +64,7 @@
     <Compile Include="SheetDefinitions\v1\TierField.cs" />
     <Compile Include="SheetDefinitions\v1\TierFolder.cs" />
     <Compile Include="SheetDefinitions\v1\TierForm.cs" />
+    <Compile Include="Validations\Rules\ValidateBlockPlanSettings.cs" />
     <Compile Include="Validations\Rules\ValidateBlockPlanSettingTiers.cs" />
     <Compile Include="Validations\Rules\LocalizableValidationRuleBase.cs" />
   </ItemGroup>

--- a/Medidata.Rave.Tsdv.Loader/Medidata.Rave.Tsdv.Loader.csproj
+++ b/Medidata.Rave.Tsdv.Loader/Medidata.Rave.Tsdv.Loader.csproj
@@ -67,6 +67,10 @@
     <Compile Include="Validations\Rules\ValidateBlockPlanSettings.cs" />
     <Compile Include="Validations\Rules\ValidateBlockPlanSettingTiers.cs" />
     <Compile Include="Validations\Rules\LocalizableValidationRuleBase.cs" />
+    <Compile Include="Validations\Rules\ValidateTierFields.cs" />
+    <Compile Include="Validations\Rules\ValidateTierFolders.cs" />
+    <Compile Include="Validations\Rules\ValidateTierForms.cs" />
+    <Compile Include="Validations\ValdiateBlockPlans.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Medidata.Rave.Tsdv.Loader.nuspec" />

--- a/Medidata.Rave.Tsdv.Loader/Medidata.Rave.Tsdv.Loader.csproj
+++ b/Medidata.Rave.Tsdv.Loader/Medidata.Rave.Tsdv.Loader.csproj
@@ -64,6 +64,7 @@
     <Compile Include="SheetDefinitions\v1\TierField.cs" />
     <Compile Include="SheetDefinitions\v1\TierFolder.cs" />
     <Compile Include="SheetDefinitions\v1\TierForm.cs" />
+    <Compile Include="Validations\Rules\ValidateBlockPlanSettingTiers.cs" />
     <Compile Include="Validations\Rules\LocalizableValidationRuleBase.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Medidata.Rave.Tsdv.Loader/Properties/AssemblyInfo.cs
+++ b/Medidata.Rave.Tsdv.Loader/Properties/AssemblyInfo.cs
@@ -37,5 +37,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("0.1.7.0")]
-[assembly: AssemblyFileVersion("0.1.7.0")]
+[assembly: AssemblyVersion("0.1.8.0")]
+[assembly: AssemblyFileVersion("0.1.8.0")]

--- a/Medidata.Rave.Tsdv.Loader/Validations/Rules/LocalizableValidationRuleBase.cs
+++ b/Medidata.Rave.Tsdv.Loader/Validations/Rules/LocalizableValidationRuleBase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Medidata.Cloud.ExcelLoader;
 using Medidata.Cloud.ExcelLoader.Validations;
 using Medidata.Cloud.ExcelLoader.Validations.Rules;
@@ -16,12 +17,12 @@ namespace Medidata.Rave.Tsdv.Loader.Validations.Rules
             _localization = localization;
         }
 
-        protected override void Validate(IExcelParser blockPlan, out IValidationMessage message, Action next)
+        protected override void Validate(IExcelLoader blockPlan, out IList<IValidationMessage> messages, Action next)
         {
-            Validate(blockPlan, out message, _localization, next);
+            Validate(blockPlan, out messages, _localization, next);
         }
 
-        protected abstract void Validate(IExcelParser blockPlan, out IValidationMessage message,
+        protected abstract void Validate(IExcelLoader blockPlan, out IList<IValidationMessage> messages,
                                          ILocalization localization, Action next);
     }
 }

--- a/Medidata.Rave.Tsdv.Loader/Validations/Rules/ValdiateBlockPlans.cs
+++ b/Medidata.Rave.Tsdv.Loader/Validations/Rules/ValdiateBlockPlans.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using Medidata.Cloud.ExcelLoader;
+using Medidata.Cloud.ExcelLoader.Helpers;
+using Medidata.Cloud.ExcelLoader.Validations;
+using Medidata.Interfaces.Localization;
+using Medidata.Rave.Tsdv.Loader.SheetDefinitions.v1;
+
+namespace Medidata.Rave.Tsdv.Loader.Validations.Rules
+{
+    public class ValdiateBlockPlans : LocalizableValidationRuleBase
+    {
+        private readonly Func<string, bool> _validDataEntryRole;
+ 
+        public ValdiateBlockPlans(ILocalization localization, Func<string, bool> validDataEntryRole) : base(localization)
+        {
+            _validDataEntryRole = validDataEntryRole;
+        }
+
+        protected override void Validate(IExcelLoader blockPlan, out IList<IValidationMessage> messages, ILocalization localization, Action next)
+        {
+            messages = new List<IValidationMessage>();
+
+            if (blockPlan.Sheet<BlockPlan>().Data.Count < 1)
+            {
+                messages.Add(String.Format("No block plan to load.").ToValidationError());
+                return;
+            }
+
+            if (blockPlan.Sheet<BlockPlan>().Data.Count > 1)
+            {
+                messages.Add(String.Format("Only one block plan can be loaded.").ToValidationError());
+                return;
+            }
+
+            var role = blockPlan.Sheet<BlockPlan>().Data[0].DataEntryRole;
+            if (!_validDataEntryRole(role))
+            {
+                messages.Add(String.Format("Data Entry {0} is not valid.", role).ToValidationError());
+                return;
+            }
+
+            next();
+        }
+    }
+}

--- a/Medidata.Rave.Tsdv.Loader/Validations/Rules/ValidateBlockPlanSettingTiers.cs
+++ b/Medidata.Rave.Tsdv.Loader/Validations/Rules/ValidateBlockPlanSettingTiers.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Medidata.Interfaces.Localization;
+using Medidata.Cloud.ExcelLoader;
+using Medidata.Cloud.ExcelLoader.Helpers;
+using Medidata.Cloud.ExcelLoader.Validations;
+using Medidata.Rave.Tsdv.Loader.SheetDefinitions.v1;
+
+namespace Medidata.Rave.Tsdv.Loader.Validations.Rules
+{
+    public class ValidateBlockPlanSettingTiers : LocalizableValidationRuleBase
+    {
+        static readonly List<string> DefaultTiers = new List<string> { "Architect Defined", "No Forms", "All Forms" };
+
+        public ValidateBlockPlanSettingTiers(ILocalization localization)
+            : base(localization)
+        {
+            
+        }
+
+        protected override void Validate(IExcelLoader blockPlan, out IList<IValidationMessage> messages, ILocalization localization, Action next)
+        {
+            messages = new List<IValidationMessage>();
+
+            foreach (var blockTier in blockPlan.Sheet<BlockPlanSetting>().Definition.ExtraColumnDefinitions)
+            {
+                if (blockPlan.Sheet<CustomTier>().Data.All(x => x.TierName != blockTier.PropertyName) &&
+                    DefaultTiers.All(x => x != blockTier.PropertyName))
+                {
+                    messages.Add(String.Format("'{0} tier header in BlockPlanSettings is not defined in CustomTier.",
+                    String.Join(",", blockTier.PropertyName)).ToValidationError());
+                }
+            }
+
+            if (messages.Count > 0)
+            {
+                return;
+            }
+
+            next();
+        }
+    }
+}

--- a/Medidata.Rave.Tsdv.Loader/Validations/Rules/ValidateBlockPlanSettingTiers.cs
+++ b/Medidata.Rave.Tsdv.Loader/Validations/Rules/ValidateBlockPlanSettingTiers.cs
@@ -28,8 +28,7 @@ namespace Medidata.Rave.Tsdv.Loader.Validations.Rules
                 if (blockPlan.Sheet<CustomTier>().Data.All(x => x.TierName != blockTier.PropertyName) &&
                     DefaultTiers.All(x => x != blockTier.PropertyName))
                 {
-                    messages.Add(String.Format("'{0} tier header in BlockPlanSettings is not defined in CustomTier.",
-                    String.Join(",", blockTier.PropertyName)).ToValidationError());
+                    messages.Add(String.Format("'{0} tier header in BlockPlanSettings is not defined in CustomTier.", blockTier.PropertyName).ToValidationError());
                 }
             }
 

--- a/Medidata.Rave.Tsdv.Loader/Validations/Rules/ValidateBlockPlanSettings.cs
+++ b/Medidata.Rave.Tsdv.Loader/Validations/Rules/ValidateBlockPlanSettings.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Medidata.Cloud.ExcelLoader;
+using Medidata.Cloud.ExcelLoader.Helpers;
+using Medidata.Cloud.ExcelLoader.Validations;
+using Medidata.Interfaces.Localization;
+using Medidata.Rave.Tsdv.Loader.SheetDefinitions.v1;
+
+namespace Medidata.Rave.Tsdv.Loader.Validations.Rules
+{
+    class ValidateBlockPlanSettings : LocalizableValidationRuleBase
+    {
+        public ValidateBlockPlanSettings(ILocalization localization) : base(localization)
+        {
+        }
+
+        protected override void Validate(IExcelLoader blockPlan, out IList<IValidationMessage> messages, ILocalization localization, Action next)
+        {
+            messages = new List<IValidationMessage>();
+            foreach (var blockPlanSetting in blockPlan.Sheet<BlockPlanSetting>().Data)
+            {
+                if (blockPlanSetting.BlockSubjectCount == 0)
+                {
+                    messages.Add(String.Format(localization.GetLocalString("tsdv_BlockSizeZeroError"), blockPlanSetting.Blocks).ToValidationError());
+                }
+                else if(!TotalTierCountValid(blockPlanSetting))
+                {
+                    messages.Add(String.Format(localization.GetLocalString("tsdv_BlockValidationError"), blockPlanSetting.Blocks).ToValidationError());
+                }
+            }
+
+            if (messages.Any())
+            {
+                return;
+            }
+
+            next();
+        }
+
+        private bool TotalTierCountValid(BlockPlanSetting block)
+        {
+            var totalTierSubjectCount = block.GetExtraProperties().Values.OfType<Int32>().Sum();
+
+            return totalTierSubjectCount == block.BlockSubjectCount;
+        }
+    }
+}

--- a/Medidata.Rave.Tsdv.Loader/Validations/Rules/ValidateTierFields.cs
+++ b/Medidata.Rave.Tsdv.Loader/Validations/Rules/ValidateTierFields.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Medidata.Cloud.ExcelLoader;
+using Medidata.Cloud.ExcelLoader.Helpers;
+using Medidata.Cloud.ExcelLoader.Validations;
+using Medidata.Interfaces.Localization;
+using Medidata.Rave.Tsdv.Loader.SheetDefinitions.v1;
+
+namespace Medidata.Rave.Tsdv.Loader.Validations.Rules
+{
+    public class ValidateTierFields : LocalizableValidationRuleBase
+    {
+        private readonly Func<string, bool> _validFormOidFunc;
+        private readonly Func<string, string, bool> _validFormFieldFunc;
+
+        public ValidateTierFields(ILocalization localization, Func<string, bool> validFormOidFunc, Func<string, string, bool> validFormFieldFunc)
+            : base(localization)
+        {
+            _validFormOidFunc = validFormOidFunc;
+            _validFormFieldFunc = validFormFieldFunc;
+        }
+
+        protected override void Validate(IExcelLoader blockPlan, out IList<IValidationMessage> messages, ILocalization localization, Action next)
+        {
+            messages = new List<IValidationMessage>();
+
+            foreach (var tierField in blockPlan.Sheet<TierField>().Data)
+            {
+                if (blockPlan.Sheet<CustomTier>().Data.All(x => x.TierName != tierField.TierName))
+                {
+                    messages.Add(String.Format("'{0} tier name in TierFields is not defined in CustomTier.", tierField.TierName).ToValidationError());
+                }
+
+                if (!_validFormOidFunc(tierField.FormOid))
+                {
+                    messages.Add(String.Format("{0} is not a valid Form OID for the project.", tierField.FormOid).ToValidationError());
+                }
+                else if (!_validFormFieldFunc(tierField.FormOid, tierField.Fields))
+                {
+                    messages.Add(
+                        String.Format("{0} is not a valid field in form {1}.", tierField.Fields, tierField.FormOid)
+                            .ToValidationError());
+                }
+
+            }
+
+            if (messages.Any())
+            {
+                return;
+            }
+
+            next();
+        }
+    }
+}

--- a/Medidata.Rave.Tsdv.Loader/Validations/Rules/ValidateTierFolders.cs
+++ b/Medidata.Rave.Tsdv.Loader/Validations/Rules/ValidateTierFolders.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Medidata.Cloud.ExcelLoader;
+using Medidata.Cloud.ExcelLoader.Helpers;
+using Medidata.Cloud.ExcelLoader.Validations;
+using Medidata.Interfaces.Localization;
+using Medidata.Rave.Tsdv.Loader.SheetDefinitions.v1;
+
+namespace Medidata.Rave.Tsdv.Loader.Validations.Rules
+{
+    public class ValidateTierFolders : LocalizableValidationRuleBase
+    {
+        private readonly Func<string, bool> _validFormFolderFunc;
+
+        public ValidateTierFolders(ILocalization localization, Func<string, bool> validFormFolderFunc) : base(localization)
+        {
+            _validFormFolderFunc = validFormFolderFunc;
+        }
+
+        protected override void Validate(IExcelLoader blockPlan, out IList<IValidationMessage> messages, ILocalization localization, Action next)
+        {
+            messages = new List<IValidationMessage>();
+
+            foreach (var tierFolder in blockPlan.Sheet<TierFolder>().Definition.ExtraColumnDefinitions)
+            {
+                if (!_validFormFolderFunc(tierFolder.PropertyName))
+                {
+                    messages.Add(String.Format("'{0} folder header in TierFolders is not valid.", tierFolder.PropertyName).ToValidationError());
+                }
+            }
+
+            if (messages.Any())
+            {
+                return;
+            }
+
+            foreach (var tierForm in blockPlan.Sheet<TierFolder>().Data)
+            {
+                if (blockPlan.Sheet<TierForm>().Data.All(x => x.TierName != tierForm.TierName && x.FormOid != tierForm.FormOID))
+                {
+                    messages.Add(String.Format("The Form OID {0} has not been selected for the tier {1} in TierForms.", tierForm.FormOID, tierForm.TierName).ToValidationError());
+                }
+            }
+
+            if (messages.Any())
+            {
+                return;
+            }
+
+            next();
+        }
+    }
+}

--- a/Medidata.Rave.Tsdv.Loader/Validations/Rules/ValidateTierForms.cs
+++ b/Medidata.Rave.Tsdv.Loader/Validations/Rules/ValidateTierForms.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Medidata.Cloud.ExcelLoader;
+using Medidata.Cloud.ExcelLoader.Helpers;
+using Medidata.Cloud.ExcelLoader.Validations;
+using Medidata.Interfaces.Localization;
+using Medidata.Rave.Tsdv.Loader.SheetDefinitions.v1;
+
+namespace Medidata.Rave.Tsdv.Loader.Validations.Rules
+{
+    public class ValidateTierForms : LocalizableValidationRuleBase
+    {
+        private readonly Func<string, bool> _validFormOidFunc;
+ 
+        public ValidateTierForms(ILocalization localization, Func<string, bool> validFormOidFunc) : base(localization)
+        {
+            _validFormOidFunc = validFormOidFunc;
+        }
+
+        protected override void Validate(IExcelLoader blockPlan, out IList<IValidationMessage> messages, ILocalization localization, Action next)
+        {
+            messages = new List<IValidationMessage>();
+
+            foreach (var tierForm in blockPlan.Sheet<TierForm>().Data)
+            {
+                if (blockPlan.Sheet<CustomTier>().Data.All(x => x.TierName != tierForm.TierName))
+                {
+                    messages.Add(String.Format("'{0} tier in TierForms is not defined in CustomTier.", tierForm.TierName).ToValidationError());
+                }
+
+                if (!_validFormOidFunc(tierForm.FormOid))
+                {
+                    messages.Add(String.Format("{0} is not a valid Form OID for the project.", tierForm.Forms).ToValidationError());
+                }
+            }
+
+            if (messages.Any())
+            {
+                return;
+            }
+
+            next();
+        }
+    }
+}


### PR DESCRIPTION
- Validate against IExcelLoader instead of IExcelParser
- ValidationRuleResult now contains a list of ValidationMessages instead of just one.
- Implemented validation rules for BlockPlan, BlockPlanSettings, TierFields, TierForms, and TierFolders. Validations 

@art2003 @chenghuang-mdsol @junshao 